### PR TITLE
Switching boutique frontend to preferred affinity

### DIFF
--- a/boutique-eshop/boutique-eshop.yaml
+++ b/boutique-eshop/boutique-eshop.yaml
@@ -754,10 +754,10 @@ metadata:
 spec:
   tls:
     - hosts:
-        - saulius-demo.onmulti.cloud
+        - boutique-demo.onmulti.cloud
       secretName: demo-tls
   rules:
-    - host: saulius-demo.onmulti.cloud
+    - host: boutique-demo.onmulti.cloud
       http:
         paths:
           - path: /

--- a/boutique-eshop/boutique-eshop.yaml
+++ b/boutique-eshop/boutique-eshop.yaml
@@ -216,24 +216,26 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
                   - key: topology.storage.csi.cast.ai/csp
                     operator: In
                     values:
                       - aws
                       - gcp
-                      #- azure
+              weight: 100
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: app
-                    operator: In
-                    values:
-                      - frontend
-              topologyKey: topology.storage.csi.cast.ai/csp
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                topologyKey: topology.storage.csi.cast.ai/csp
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - frontend
+              weight: 100
       containers:
         - name: server
           image: anjmao/boutique-eshot:0.0.1
@@ -752,10 +754,10 @@ metadata:
 spec:
   tls:
     - hosts:
-        - boutique-demo.onmulti.cloud
+        - saulius-demo.onmulti.cloud
       secretName: demo-tls
   rules:
-    - host: boutique-demo.onmulti.cloud
+    - host: saulius-demo.onmulti.cloud
       http:
         paths:
           - path: /


### PR DESCRIPTION
If a cluster is unpaused with the boutique app installed, there is a race condition between kubelet node label sync and pod scheduling which makes the frontend pods fail to start. This change will allow the pods to always start.